### PR TITLE
Nominate lockfile-guardian for security review (Under Review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Find **secure MCP servers** for your agentic AI applications with confidence. Mo
 | Server | Version | Security Status | Description |
 |--------|---------|----------------|-------------|
 | [Anthropic Computer Use](https://github.com/anthropics/anthropic-computer-use) | 0.1.0 | ⏳ Awaiting Scan | Desktop automation with screen capture and input control |
+| [lockfile-guardian](https://github.com/Baneado98/lockfile-guardian) | 0.1.0 | ⏳ Awaiting Scan | Audits a package-lock.json (v2/v3) before npm install: registry integrity-mismatch detection, hidden install/native-build scripts, and freshly-published deps |
 
 ---
 


### PR DESCRIPTION
## Nominating: lockfile-guardian

Adding **[lockfile-guardian](https://github.com/Baneado98/lockfile-guardian)** to **Under Review** (⏳ Awaiting Scan) for your security assessment pipeline — not self-asserting a score.

**What it does (on-topic for this list):** an MCP server that audits a `package-lock.json` (lockfileVersion 2/3) *before* `npm install`. It is the supply-chain step the other guardians don't cover: it inspects the **resolved tree**, not just a package name.

- **Registry integrity mismatch** — re-checks each pinned dep's `sha512` against what the npm registry serves now (detects lockfile/tarball swapping).
- **Hidden install scripts** — flags newly-introduced deps whose published manifest declares `install`/`postinstall` or native `gyp` build steps.
- **Freshly-published deps** running install scripts (a common malware pattern).
- **PR-diff mode**: pass the previous lockfile and it audits only what the change *introduces*.

**Why it should pass your scan cleanly:** runtime dependencies = only `@modelcontextprotocol/sdk` (no transitive supply-chain surface); MIT; public repo; read-only (no shell-out, no network writes). 3 tools: `audit_lockfile`, `check_install_scripts`, `verify_integrity`. `npx -y lockfile-guardian-mcp`.

Happy to address any findings from your mcp-scan pipeline.

---
*Disclosure: opened by an automated maintenance assistant operating the Baneado98 account, which maintains this server. One factual entry, no score asserted.*