### PR TITLE
New Server Submission: PickySteve

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Find **secure MCP servers** for your agentic AI applications with confidence. Mo
 | Server | Version | Security Status | Description |
 |--------|---------|----------------|-------------|
 | [Anthropic Computer Use](https://github.com/anthropics/anthropic-computer-use) | 0.1.0 | ⏳ Awaiting Scan | Desktop automation with screen capture and input control |
+| [PickySteve](https://github.com/KernelLord/pickysteve) | 0.1.0 | ⏳ Awaiting Scan | Skill router and context picker for coding agents with dual-scan prompt-injection gating |
 
 ---
 


### PR DESCRIPTION
**Repository**: https://github.com/KernelLord/pickysteve
**Version**: 0.1.0
**MCP Protocol**: 2025-06-18 (stdio transport via the `mcp` Python SDK)
**Language**: Python 3.11
**Category**: Community Servers (submitted to Under Review per process)

**Description**:
Skill router and context picker for coding agents. A cheap local model routes each prompt to the right skill via hybrid BM25 + embedding retrieval (RRF-fused), cross-encoder rerank with a calibrated floor, and an LLM judge, then assembles one minimal context bundle. Exposes `pick_context(request)` and `list_skills()` over stdio.

**Security Features**:
- Dual-scan prompt-injection gate (stackone-defender, ONNX): scans the raw request AND every retrieved document before assembly, fail-closed
- Per-call random-nonce boundaries around untrusted content (static delimiters proved forgeable — finding documented in SECURITY_AUDIT.md)
- Red-team results: 100% detection / 0 bypasses on a 180-payload corpus (14 evasion families), 0/43 false positives on the real skill registry
- CI: SHA-pinned actions, minimal token permissions, OSV-Scanner, Trivy, CodeQL, Bandit, OSSF Scorecard, Dependabot

**Required Permissions**:
- Local filesystem read of its own skill registry (no network required in the security path; local Ollama by default)
- Optional outbound HTTPS only if configured with a cloud model endpoint

**Deployment**:
- Install: `git clone` + `uv` (Python 3.11 venv); no PyPI package yet
- Config via `PS_*` environment variables (see `pickysteve/config.py`)
- Connector installer wires 18 coding agents (MCP stdio + OpenAI-compatible proxy on :8077)

**Known security considerations** (documented in the repo):
- Latin-script non-English injection (e.g. Spanish) can bypass the bundled English-only classifier in some cases
- Thresholds are calibrated per judge model; swapping models requires re-running `eval/calibrate.py`

Disclosure: I'm the project author; this PR was prepared by Claude (agent) on my behalf. Happy to have the scanners tear into it — that's the point.